### PR TITLE
Attempt fix Travis CI using OTP 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: C
+language: erlang
+otp_release: 17.3
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Please refer to commit message for details.

Sample output of [last (failing) Travis CI build](https://travis-ci.org/FlowForwarding/lincx/builds/44946059):

```
...
==> lager (compile)

ERROR: OTP release R16B01 does not match required regex 17

ERROR: compile failed while processing /home/lci/lincx/deps/lager: rebar_abort

Connection to erlangonxen.org closed.

The command "ssh -tA -i id_rsa -o StrictHostKeychecking=no -o CheckHostIP=no lci@erlangonxen.org ./lci $TRAVIS_COMMIT" exited with 1.

Done. Your build exited with 1.
```
