### PR TITLE
Allow "ipconf: dhcp" in lincx.yml

### DIFF
--- a/apps/linc/src/default_railing.erl
+++ b/apps/linc/src/default_railing.erl
@@ -146,6 +146,8 @@ yml(Cfg) ->
 
 	conf(Ports, Queues, Controllers, Ipconf, ListenIp, ListenPort, Memory, NineP ++ " " ++ Secret).
 
+check_opt({"ipconf", "dhcp"}) ->
+	ok;
 check_opt({"ipconf", Ipconf}) when is_list(Ipconf) ->
 	lists:foreach(
 		fun


### PR DESCRIPTION
Make the option checker allow an ipconf setting of "dhcp".  This option
is already handled correctly in other parts of the code.
